### PR TITLE
Upgrade to PostCSS 6 and add the custom parser, stringifier and syntax options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## [1.0.1] - 2017-08-16
+## [1.1.0] - 2017-08-17
 ### Added
 - PostCSS 6.
-- `parser` options.
+- `parser` option.
+- `stringifier` option.
+- `syntax` option.
 
 ## [1.0.0] - 2016-04-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.1] - 2017-08-16
+### Added
+- PostCSS 6.
+- `parser` options.
+
 ## [1.0.0] - 2016-04-20
 ### Added
 - `pattern` options, supporting excludes.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Build script example:
 var metalsmith = require('metalsmith');
 var markdown = require('metalsmith-markdown');
 var postcss = require('metalsmith-with-postcss');
+var sugarss = require('sugarss');
+var rename = require('metalsmith-rename';
 
 
 metalsmith(__dirname)
@@ -45,7 +47,7 @@ metalsmith(__dirname)
   .destination('pub')
   .use(postcss({
     pattern: ['**/*.sss', '!**/_*/*', '!**/_*'], //For SugarSS,
-    parser: require('sugarss'),
+    parser: sugarss,
     plugins: {
       'postcss-import': {},
       'postcss-if-media': {},
@@ -56,7 +58,7 @@ metalsmith(__dirname)
       'autoprefixer': {}
     }
   }))
-  .use(require('metalsmith-rename')([[/\.sss$/, '.css']])) //Renames processed files to CSS
+  .use(rename)([[/\.sss$/, '.css']])) //Renames processed files to CSS
   .use(markdown({
     gfm: true,
     tables: true

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ metalsmith(__dirname)
     - __Description:__ Only process files that match this pattern, can be an array of multiple patterns, following [multimatch](https://github.com/sindresorhus/multimatch) rules. The default patterns exclude any files or folders prefixed with an underscore.
   - `parser`
     - __Default value:__ undefined
-    - __Description:__ A parser module like [`require('sugarss')`](https://github.com/postcss/sugarss).
+    - __Description:__ A custom parser module like [`require('sugarss')`](https://github.com/postcss/sugarss).
   - `plugins`
     - __Default value:__ {}
     - __Description:__ A collection of plugin module names as keys and any options for them as values.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ metalsmith(__dirname)
   - `stringifier`
     - __Default value:__ undefined
     - __Description:__ A [custom stringifier module](http://api.postcss.org/global.html#processOptions) passed directly to PostCSS.
-  - `parser`
+  - `syntax`
     - __Default value:__ undefined
     - __Description:__ A [shorthand object for the parser and stringifier](http://api.postcss.org/global.html#processOptions) passed directly to PostCSS.
   - `plugins`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ metalsmith(__dirname)
   .source('src')
   .destination('pub')
   .use(postcss({
-    pattern: ['**/*.sss', '!**/_*/*', '!**/_*'], //For SugarSS
+    pattern: ['**/*.sss', '!**/_*/*', '!**/_*'], //For SugarSS,
+    parser: require('sugarss'),
     plugins: {
       'postcss-import': {},
       'postcss-if-media': {},

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ metalsmith(__dirname)
       'autoprefixer': {}
     }
   }))
-  .use(rename)([[/\.sss$/, '.css']])) //Renames processed files to CSS
+  .use(rename([[/\.sss$/, '.css']])) //Renames processed files to CSS
   .use(markdown({
     gfm: true,
     tables: true

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ metalsmith.json config example:
   "plugins": {
     "metalsmith-with-postcss": {
       pattern: ['**/*.css', '!**/_*/*', '!**/_*'], //This is the default.
-      parser: require('sugarss'),
       plugins: {
         'postcss-import': {},
         'postcss-if-media': {},

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ metalsmith(__dirname)
   - `pattern`
     - __Default value:__ `['**/*.css', '!**/_*/*', '!**/_*']`
     - __Description:__ Only process files that match this pattern, can be an array of multiple patterns, following [multimatch](https://github.com/sindresorhus/multimatch) rules. The default patterns exclude any files or folders prefixed with an underscore.
+  - `parser`
+    - __Default value:__ undefined
+    - __Description:__ A parser module like [`require('sugarss')`](https://github.com/postcss/sugarss).
   - `plugins`
     - __Default value:__ {}
     - __Description:__ A collection of plugin module names as keys and any options for them as values.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ metalsmith.json config example:
 {
   "plugins": {
     "metalsmith-with-postcss": {
-      pattern: ['**/*.sss', '!**/_*/*', '!**/_*'], //For SugarSS
+      pattern: ['**/*.css', '!**/_*/*', '!**/_*'], //This is the default.
       parser: require('sugarss'),
       plugins: {
         'postcss-import': {},

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ metalsmith.json config example:
 {
   "plugins": {
     "metalsmith-with-postcss": {
-      pattern: ['**/*.css', '!**/_*/*', '!**/_*'], //This is the default.
+      pattern: ['**/*.sss', '!**/_*/*', '!**/_*'], //For SugarSS
+      parser: require('sugarss'),
       plugins: {
         'postcss-import': {},
         'postcss-if-media': {},
@@ -44,7 +45,7 @@ metalsmith(__dirname)
   .source('src')
   .destination('pub')
   .use(postcss({
-    pattern: ['**/*.css', '!**/_*/*', '!**/_*'], //This is the default.
+    pattern: ['**/*.sss', '!**/_*/*', '!**/_*'], //For SugarSS
     plugins: {
       'postcss-import': {},
       'postcss-if-media': {},
@@ -55,6 +56,7 @@ metalsmith(__dirname)
       'autoprefixer': {}
     }
   }))
+  .use(require('metalsmith-rename')([[/\.sss$/, '.css']])) //Renames processed files to CSS
   .use(markdown({
     gfm: true,
     tables: true
@@ -74,7 +76,13 @@ metalsmith(__dirname)
     - __Description:__ Only process files that match this pattern, can be an array of multiple patterns, following [multimatch](https://github.com/sindresorhus/multimatch) rules. The default patterns exclude any files or folders prefixed with an underscore.
   - `parser`
     - __Default value:__ undefined
-    - __Description:__ A custom parser module like [`require('sugarss')`](https://github.com/postcss/sugarss).
+    - __Description:__ A [custom parser module](http://api.postcss.org/global.html#processOptions) passed directly to PostCSS.
+  - `stringifier`
+    - __Default value:__ undefined
+    - __Description:__ A [custom stringifier module](http://api.postcss.org/global.html#processOptions) passed directly to PostCSS.
+  - `parser`
+    - __Default value:__ undefined
+    - __Description:__ A [shorthand object for the parser and stringifier](http://api.postcss.org/global.html#processOptions) passed directly to PostCSS.
   - `plugins`
     - __Default value:__ {}
     - __Description:__ A collection of plugin module names as keys and any options for them as values.

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ module.exports = exports = function(options) {
   var defaults = {
     pattern: ['**/*.css', '!**/_*/*', '!**/_*'],
     parser: undefined,
+    stringifier: undefined,
+    syntax: undefined,
     plugins: {},
     map: {inline: true},
     removeExcluded: false
@@ -58,6 +60,8 @@ module.exports = exports = function(options) {
         from: path.join(metalsmith._source, key),
         to: path.join(metalsmith._destination, key),
         parser: options.parser,
+        stringifier: options.stringifier,
+        syntax: options.syntax,
         map: options.map
       })
       .then((function(file, result) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var postcss = require('postcss');
 module.exports = exports = function(options) {
   var defaults = {
     pattern: ['**/*.css', '!**/_*/*', '!**/_*'],
+    parser: undefined,
     plugins: {},
     map: {inline: true},
     removeExcluded: false
@@ -56,6 +57,7 @@ module.exports = exports = function(options) {
       var promise = processor.process(css, {
         from: path.join(metalsmith._source, key),
         to: path.join(metalsmith._destination, key),
+        parser: options.parser,
         map: options.map
       })
       .then((function(file, result) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/arccoza/metalsmith-with-postcss",
   "dependencies": {
     "minimatch": "^3.0.0",
-    "postcss": "^5.0.19"
+    "postcss": "^6.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/arccoza/metalsmith-with-postcss",
   "dependencies": {
     "minimatch": "^3.0.0",
-    "postcss": "^6.x"
+    "postcss": "6.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-with-postcss",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Metalsmith plugin for PostCSS.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/arccoza/metalsmith-with-postcss",
   "dependencies": {
     "minimatch": "^3.0.0",
-    "postcss": "^6.0.9"
+    "postcss": "^6.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-with-postcss",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A Metalsmith plugin for PostCSS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I needed to use the SugarSS syntax with PostCSS, and noticed that the plugin didn't support the PostCSS parser options yet. 

I just upgraded the package, and added the option in with a working default. I hope this is acceptable.